### PR TITLE
Fixes bug in Neuigkeiten mobile view, see picture

### DIFF
--- a/app/views/home/_beispiele.html.erb
+++ b/app/views/home/_beispiele.html.erb
@@ -7,7 +7,7 @@
       <%= link_to I18n.t("beispiel.add"), new_beispiel_path, :class=>"linkbox"%>
     </div>
   </div>
-  <ul class="unstyled linkbox-list" style="margin-top:5px;margin-bottom:5px;">
+  <ul class="unstyled linklist">
     <% @beispiele.each do |b| %>
     <li>
       <%= link_to b.lva, {:class=> :linkbox} do %>

--- a/app/views/lvas/_lva_semester.html.erb
+++ b/app/views/lvas/_lva_semester.html.erb
@@ -1,5 +1,8 @@
-
-<div class="lva-semester">
- <%=lva.lvanr.to_s %> <b><%= link_to lva.full_name, lva_path(lva)%></b>  <%= lva.ects %> ECTS / <%= lva.stunden %> Std<br>
- 
-</div> 
+<div class="lva-semester" style="overflow:auto;">
+	<span>  
+    <%=lva.lvanr.to_s %> <b><%= link_to lva.full_name, lva_path(lva)%></b>
+  </span>
+  <span style="float:right;">
+    <%= lva.ects %> ECTS / <%= lva.stunden %> Std
+  </span>
+</div>

--- a/app/views/neuigkeiten/show.html.erb
+++ b/app/views/neuigkeiten/show.html.erb
@@ -23,6 +23,7 @@ end
 <div class="content-column content-wrap">
 <p id="notice"><%= notice %></p>
 <div class="contentbox">
+<div class="row-fluid">
 <span>
   <%= ff_icon(@neuigkeit.rubrik.icon) unless @neuigkeit.rubrik.icon.nil? or @neuigkeit.rubrik.icon.empty? %>&nbsp;<%= @neuigkeit.rubrik.name %>
 </span>
@@ -30,6 +31,7 @@ end
   <%= @neuigkeit.author.email.to_s unless @neuigkeit.try(:author).try(:email).to_s %> 
   <%= @neuigkeit.author.text+ " "+ I18n.t("neuigkeit.am")+" " + I18n.l(@neuigkeit.try(:datum).try(:to_date)) unless @neuigkeit.try(:datum).try(:to_date).nil?  %>
 </span>
+</div>
 <div class="media">
   <% unless @neuigkeit.picture.big_thumb.to_s.empty? %>
   <div class="pull-left" href="#">

--- a/app/views/themes/blue1/home/index.html.erb
+++ b/app/views/themes/blue1/home/index.html.erb
@@ -1,11 +1,11 @@
-<div class="content-wrap content-column">
+<div class="content-wrap content-column" style="max-width:90em;">
  <h1><%= I18n.t('home.willkommen') %></h1>
 <%= raw(@starttopic.text) %>
 
 
 <div class="container-fluid">
 <div class="row-fluid">
-<div class="span6">
+<div class="span5">
   
   <ul class="linklist">
     <li>
@@ -21,7 +21,9 @@
 
     </li>
     <li><%= link_to ffi1_icon("books19")+"Beispielsammlung", studium_path(Studium.first, {:ansicht=>'semesteransicht'}) ,class: :btn ,class: :linkbox %></li>
+
     <li><%= link_to "Alte Beispielsammlung", "http://www.fet.at/alt/bin/view/Beispielsammlung/WebHome" ,class: :btn ,class: :linkbox %></li>
+
 
   </ul>
   <!-- <div class="alert">
@@ -49,21 +51,12 @@
 
   <%= render 'beispiele' %>
 </div>
-<div class="span6">
- <ul class="unstyled linkbox-list" style="max-width:70em">
+<div class="span7">
+ <ul class="unstyled linklist">
 	<% @neuigkeiten.each do |n| %>
 	<li><%= render n if can?(:show, n) %> </li>
 	<% end %>
       </ul>
-Verschiedene Styles
-<ul>
-<li> <%= link_to "Darkblue", home_index_path({:theme=>"darkblue"}) %></li>
-<li> <%= link_to "Blue1", home_index_path({:theme=>"blue1"}) %></li>
-
-<li> <%= link_to "2003", home_index_path({:theme=>"2003"}) %></li>
-<li> <%= link_to "white_1", home_index_path({:theme=>"white_1"}) %></li>
-</ul>
-
 </div>
 </div>
 </div>


### PR DESCRIPTION
If display width forced header (Rubrik / User+Date) to display in two lines
whole content of Neuigkeit was squeezed to the width of the whitespace left
to the lower line